### PR TITLE
Update TAT data changes to local storage and post message

### DIFF
--- a/src/editor/extensions/ext-tactile-render/ext-tactile-render.js
+++ b/src/editor/extensions/ext-tactile-render/ext-tactile-render.js
@@ -90,6 +90,17 @@ const encryptData = async function (svgEditor, svgString) {
     return svgString
 }
 
+const updateStorage = async function (channelTitle, channelId, secret) {
+  channelTitle = await encryptData(svgEditor, channelTitle);
+  channelId = await encryptData(svgEditor, channelId);
+  secret = await encryptData(svgEditor, secret);
+  const store = {"channelId": channelId, "graphicTitle": channelTitle, 
+    "secretKey": secret, "graphicBlob": graphic}
+  svgEditor.storage.setItem('tat-storage-data', JSON.stringify(store));
+  let messageObj = { "messageFrom": "AuthoringTool", "storageData": JSON.stringify(store) };
+  window.postMessage(messageObj, "*");
+}
+
 /**
  * @class SeLabelDialog
  */
@@ -158,6 +169,7 @@ export class SeTactileRenderDialog extends HTMLElement {
           graphicId = this._shadowRoot.querySelector('#id_value').value
           secretKey = this._shadowRoot.querySelector('#secret_value').value
           layerSelected = this._shadowRoot.querySelector('#layer_select_dd').value
+          updateStorage(graphicTitle, graphicId, secretKey);
           this.$dialog.close()
         }
         break


### PR DESCRIPTION
This PR merges TAT side changes required to complete Shared-Reality-Lab/IMAGE-browser#401.

Particularly, TAT now updates the local storage and posts a message each time the publish toolbox is closed.