### PR TITLE
Fixing single element layers

### DIFF
--- a/packages/svgcanvas/core/draw.js
+++ b/packages/svgcanvas/core/draw.js
@@ -400,9 +400,16 @@ export class Drawing {
    */
   mergeLayer (hrService) {
     const currentGroup = this.current_layer.getGroup()
-    const prevGroup = currentGroup.previousElementSibling
+    /*const prevGroup = currentGroup.previousElementSibling
     if (!prevGroup) {
       return
+    }*/
+    let prevGroup = currentGroup.previousElementSibling
+    while (!isLayerElement(prevGroup)){
+      prevGroup = prevGroup.previousElementSibling
+      if (!prevGroup) {
+        return
+      }
     }
 
     hrService.startBatchCommand('Merge Layer')

--- a/packages/svgcanvas/core/draw.js
+++ b/packages/svgcanvas/core/draw.js
@@ -520,7 +520,17 @@ export class Drawing {
           if (isLayerElement(child)) {
             const name = findLayerNameInGroup(child)
             layernames.push(name)
-            layer = new Layer(name, child)
+            if (child.tagName === 'g') {
+              layer = new Layer(name, child)
+            } else {
+              child.removeAttribute('data-image-layer')
+              layer = new Layer(name, child, this.svgElem_)
+              layer.appendChildren([child])
+              if (child.hasAttribute('aria-label')) {
+                let el = document.querySelector("[data-image-layer='"+name+"']")
+                el.setAttribute('aria-label', child.getAttribute('aria-label'))
+              }
+            }
             this.all_layers.push(layer)
             this.layer_map[name] = layer
           } else {


### PR DESCRIPTION
Earlier single element layers were not working well with layer features like merging layers or even adding elements.

The following changes have been made to address this: 
1. Single element layers are moved into a new group to retain the functionality of layers without making changes to the add, delete elements and also merge layers.
2. The mergeLayer function is modified to consider only layers so that layers are not accidentally merged with other elements, e.g.<title>.