### PR TITLE
Configure serverUrl using config.js at runtime

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -28,8 +28,6 @@ const getDirectories = source => {
     .filter(i => isDirectory(i))
 }
 
-const serverUrl = process.env.SERVER_URL;
-console.log('Server URL:', serverUrl);
 
 // capture the list of files to build for extensions and ext-locales
 const extensionDirs = getDirectories('src/editor/extensions')
@@ -67,10 +65,6 @@ const config = [
       }
     ],
     plugins: [
-      replace({
-        preventAssignment: true,
-        'process.env.SERVER_URL': JSON.stringify(process.env.SERVER_URL),
-      }),
       copy({
         targets: [
           {

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -324,8 +324,6 @@ class Editor extends EditorStartup {
     // Add empty password
     this.password = null
 
-    this.server = process.env.SERVER_URL; 
-
     // Add empty ID and secret key
     // this.graphicId = ""// Math.random().toString().replace('9', '').substring(2, 8)
     // this.secretKey = "" // crypto.randomUUID()

--- a/src/editor/extensions/ext-tactile-render/ext-tactile-render.js
+++ b/src/editor/extensions/ext-tactile-render/ext-tactile-render.js
@@ -21,6 +21,7 @@ var secretKey = ""
 var graphic = ""
 var coords = ""
 var placeId = ""
+var serverUrl = window.APP_CONFIG?.serverUrl
 
 const loadExtensionTranslation = async function (svgEditor) {
   let translationModule
@@ -315,9 +316,9 @@ connectedCallback () {
     svgString = await encryptData(svgEditor, svgString)
 
     if (graphicId == ""){
-      xhr.open("POST", svgEditor.server + "create");
+      xhr.open("POST", serverUrl + "monarch/create");
     } else {
-      xhr.open("POST", svgEditor.server + "update/" + graphicId);
+      xhr.open("POST", serverUrl + "monarch/update/" + graphicId);
     }
     xhr.setRequestHeader("Content-Type", "application/json");
     xhr.setRequestHeader("Access-Control-Allow-Origin", '*');

--- a/src/editor/index.html
+++ b/src/editor/index.html
@@ -29,6 +29,7 @@
 </body>
 <!-- If you do not wish to add extensions by URL, you can add calls
       within the following file to svgEditor.setConfig -->
+<script src="config.js"></script>
 <script type="module">
   import Editor from './Editor.js'
   /* for available options see the file `docs/tutorials/ConfigOptions.md */


### PR DESCRIPTION
With the changes made in this PR, tactile-render extension reads the SERVER_URL from a script config.js created at runtime. With this change, we will no longer need to hardcode the URLs in the Dockerfile and can use env variables. Partially addresses issue Shared-Reality-Lab/IMAGE-server#1059. 

TESTING:
Tested that the tat is able to update content to the correct server based on the environment variable value SERVER_URL using override (tested by swapping between prod and dev server urls) 
