### PR TITLE
Replace display='inline' before sending svg to server

### DIFF
--- a/src/editor/extensions/ext-tactile-render/ext-tactile-render.js
+++ b/src/editor/extensions/ext-tactile-render/ext-tactile-render.js
@@ -254,7 +254,7 @@ connectedCallback () {
       }
       svgDoc.querySelector('g[data-image-layer="fullImage"]').remove()
     }
-    svgString = new XMLSerializer().serializeToString(svgDoc)
+    svgString = new XMLSerializer().serializeToString(svgDoc).replaceAll('display="inline"', "")
     
     /*const password = svgEditor.password
 


### PR DESCRIPTION
Labels did not work on the Monarch after toggling the layer visibility as hiding and then showing the layers introduced `display='inline'` attribute. 

To avoid making changes on the Monarch application, this PR introduces a temporary non-ideal fix removing `display='inline'` from the SVG before sending it to the server. 

Tested by building application locally and sending requests to test server.
Layer after toggling visibility:
```
 <g data-image-layer="Layer 1" display="inline">
  <rect aria-label="Test" fill="#FF0000" height="179" id="svg_1" stroke="#000000" stroke-width="5" width="163" x="268.6" y="147.4"/>
 </g>
```
Layer sent to server:
```
 <g data-image-layer="Layer 1" >
  <rect aria-label="Test" fill="#FF0000" height="179" id="svg_1" stroke="#000000" stroke-width="5" width="163" x="268.6" y="147.4"/>
 </g>
```
Also checked that the labels now work as expected on the Monarch. 

The ideal fix for this would be to fix the XPath queries on the Monarch to filter out only the elements that have `display='none'` rather than `display` (Tracked by #)


